### PR TITLE
make the setup script copy files from the images directory correctly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,9 @@ else:  # Not Windows
         scripts=['openxenmanager'],
         package_data={'OXM': ['oxc.glade',
                               'oxc.conf',
-                              'images/*',
+                              'images/*.gif',
+                              'images/*.png',
+                              'images/menu/*.png',
                               'images_map/*'],
                       'pygtk_chart': ['data/tango.color']},
         classifiers=[


### PR DESCRIPTION
Running "python2 setup.py install --root="<some directory>" --optimize=1" results in the following error:
error: can't copy 'src/OXM/images/menu': doesn't exist or not a regular file

This patch fixes the setup.py script.
