### PR TITLE
Make application exit on close of main window.

### DIFF
--- a/src/OXM/ui/main_window.glade
+++ b/src/OXM/ui/main_window.glade
@@ -1304,6 +1304,7 @@
     <property name="window_position">center</property>
     <property name="default_width">768</property>
     <property name="default_height">668</property>
+    <signal name="destroy" handler="on_window_destroy" swapped="no"/>
     <child>
       <object class="GtkVBox" id="vbox1">
         <property name="visible">True</property>


### PR DESCRIPTION
This patch makes a window close call the same function as the menu choice "Exit".

Currently closing the main window of oxm leaves the process running. This fixes that issue.

(I'm using i3 window manager, so behaviour might be different on different WMs)