### PR TITLE
Fix bugs in setting static maximum on a VM

### DIFF
--- a/src/OXM/oxcSERVER_vm.py
+++ b/src/OXM/oxcSERVER_vm.py
@@ -38,8 +38,8 @@ class oxcSERVERvm(oxcSERVERvmnetwork,oxcSERVERvmstorage,oxcSERVERvmsnapshot):
         res = self.connection.VM.set_memory_dynamic_range(self.session_uuid, ref, str(int(dynamicmin)*1024*1024), str(int(dynamicmax)*1024*1024))
         if "Value" in res:
             if int(actual_staticmax) != int(int(staticmax)*1024*1024):
-                res = self.connection.VM.set_memory_static_range(self.session_uid, ref, actual_staticmin, staticmax)
-                if "Value" not in "OK":
+                res = self.connection.VM.set_memory_static_range(self.session_uuid, ref, actual_staticmin, int(int(staticmax)*1024*1024))
+                if "Value" not in res:
                     self.wine.show_error_dlg(str(res["ErrorDescription"]))
         else:
             self.wine.show_error_dlg(str(res["ErrorDescription"]))


### PR DESCRIPTION
Attempt at fixing the feature to set static maximum on a VM.

I just installed XenServer to experiment with it, and since I use Linux, I tried using OpenXenManager. I ran into a bug trying to change the static maximum on a VM and figured I'd take a shot at it. It seems to work now; I tried to avoid changing more than I had to. I don't know a ton about XenServer or about the Xen protocol, so it's possible I made a dumb mistake in trying to fix it, so please make sure you take a close look at what I changed :)

The bug was that changing the static maximum didn't work at all, at least in my environment.

Thanks for all your work on OpenXenManager, it's nice to have a Linux GUI to manage it.

(I'm not sure if such a trivial change requires me to add a notice to the file header per the GPL... If you'd like, I'd be more than happy to add it.)
