### PR TITLE
[Feature] Allow multiple VNC windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ docs/_build/
 
 # Other Stuff
 Thumbs.db
+.DS_Store

--- a/src/OXM/oxc.conf
+++ b/src/OXM/oxc.conf
@@ -15,3 +15,4 @@ check_show_network = True
 check_show_halted_vms = False
 [options]
 vnc_viewer = 'C:\Program Files\TightVNC\tvnviewer.exe'
+multiple_vnc = False

--- a/src/OXM/tunnel.py
+++ b/src/OXM/tunnel.py
@@ -141,5 +141,3 @@ class Tunnel:
             del self
         except:
             pass
-
-

--- a/src/OXM/window_menuitem.py
+++ b/src/OXM/window_menuitem.py
@@ -1019,12 +1019,12 @@ class oxcWindowMenuItem:
         """
         "Send Ctrl-Alt-Del" menu item is pressed (tools menu)
         """
-        self.tunnel.send_data("\xfe\x01\x00\x00\x00\x00\x00\x1d")
-        self.tunnel.send_data("\xfe\x01\x00\x00\x00\x00\x00\x38")
-        self.tunnel.send_data("\xfe\x01\x00\x00\x00\x00\x00\xd3")
-        self.tunnel.send_data("\xfe\x00\x00\x00\x00\x00\x00\x1d")
-        self.tunnel.send_data("\xfe\x00\x00\x00\x00\x00\x00\x38")
-        self.tunnel.send_data("\xfe\x00\x00\x00\x00\x00\x00\xd3")
+        self.tunnel[data].send_data("\xfe\x01\x00\x00\x00\x00\x00\x1d")
+        self.tunnel[data].send_data("\xfe\x01\x00\x00\x00\x00\x00\x38")
+        self.tunnel[data].send_data("\xfe\x01\x00\x00\x00\x00\x00\xd3")
+        self.tunnel[data].send_data("\xfe\x00\x00\x00\x00\x00\x00\x1d")
+        self.tunnel[data].send_data("\xfe\x00\x00\x00\x00\x00\x00\x38")
+        self.tunnel[data].send_data("\xfe\x00\x00\x00\x00\x00\x00\xd3")
 
     def on_menuitem_migratetool_activate(self, widget, data=None):
         """


### PR DESCRIPTION
# Description

This PR adds a new advanced setting (or configuration flag) - `multiple_vnc` to OXM so multiple VNC windows can be opened at the same time. By default the flag is set to False, so the behavior of OXM continues to be the same.

# Motivation and Context

My use case for OXM requires multiple VM VNC windows to be opened so I can perform network experiments and see the live communication between virtual machines. This is something I can achieve using Citrix XenCenter but not with OpenXenmanager. By default, OXM will remove any VNC session if the tab selected is different from "console". This PR changes this behavior by keeping dictionaries for the gtk-vnc objects, gtk windows (if undocked) and vnc pid's (osx). Also, under OSX, if you close the external VNC window OXM fails to close. Added a few changes to the "exiting" logic so OXM can close gracefully. 

# How Has This Been Tested?

It was extensively tested (manually) in OSX (using tigerVNC) and Linux (Arch Linux and Lubuntu). Some testing was done for Windows.

# Screenshots (if appropriate):
![OXM](https://s17.postimg.org/ja7xgrq3j/Screenshot_from_2017_03_06_01_35_00.png "Multiple VNC")


# Types of change

 - New feature (non-breaking change which adds functionality)

# Roadmap

It would be great if this could be accepted and merged upstream so I don't have to keep a separate version. I plan to improve a bit the reboot (ctr+alt+del) logic if the vnc window is undocked in Linux. Right now, the window is being closed and the user has to manually select the console tab again to access the VNC. In the future I plan to restart the VNC session in the window itself like the XenServer client.